### PR TITLE
Make SSH compression for remote copy configurable

### DIFF
--- a/nova/conf/libvirt.py
+++ b/nova/conf/libvirt.py
@@ -921,6 +921,13 @@ Related options:
 * [workarounds]/ensure_libvirt_rbd_instance_dir_cleanup
 * compute.force_raw_images
 """),
+    cfg.BoolOpt('remote_copy_compression',
+                default=False,
+                help="""
+Use SSH compression to copy ephemeral disks to a remote host. On fast
+local networks compression often reduces the copy bandwidth because the CPU
+cannot compress fast enough.
+"""),
     cfg.StrOpt('images_volume_group',
                help="""
 LVM Volume Group that is used for VM images, when you specify images_type=lvm

--- a/nova/tests/unit/virt/libvirt/test_driver.py
+++ b/nova/tests/unit/virt/libvirt/test_driver.py
@@ -21798,13 +21798,14 @@ class LibvirtDriverTestCase(test.NoDBTestCase, TraitsComparisonMixin):
             self, ctxt, flavor_obj, mock_execute, mock_exists, mock_rename,
             mock_is_shared, mock_get_host_ip, mock_destroy,
             mock_get_disk_info, mock_vtpm, mock_unplug_vifs,
-            mock_cleanup, block_device_info=None, params_for_instance=None):
+            mock_cleanup, block_device_info=None, params_for_instance=None,
+            images_type='qcow2', assert_compression=False):
         """Test for nova.virt.libvirt.driver.LivirtConnection
         .migrate_disk_and_power_off.
         """
 
         instance = self._create_instance(params=params_for_instance)
-        disk_info = list(fake_disk_info_byname(instance).values())
+        disk_info = list(fake_disk_info_byname(instance, images_type).values())
         disk_info_text = jsonutils.dumps(disk_info)
         mock_get_disk_info.return_value = disk_info
 
@@ -21831,10 +21832,25 @@ class LibvirtDriverTestCase(test.NoDBTestCase, TraitsComparisonMixin):
             instance.uuid, mock.ANY, mock.ANY, '10.0.0.1', mock.ANY, mock.ANY)
         mock_unplug_vifs.assert_called_once()
 
+        assert_func = (
+            self.assertIn if assert_compression
+            else self.assertNotIn
+        )
+        for i, info in enumerate(disk_info):
+            self.assertIn('scp', mock_execute.call_args_list[i + 1].args)
+            assert_func('-C', mock_execute.call_args_list[i + 1].args)
+
     def test_migrate_disk_and_power_off(self):
         flavor = {'root_gb': 10, 'ephemeral_gb': 20}
         flavor_obj = objects.Flavor(**flavor)
         self._test_migrate_disk_and_power_off(self.context, flavor_obj)
+
+    def test_migrate_disk_and_power_off_compressed(self):
+        CONF.set_override('remote_copy_compression', True, group='libvirt')
+        flavor = {'root_gb': 10, 'ephemeral_gb': 20}
+        flavor_obj = objects.Flavor(**flavor)
+        self._test_migrate_disk_and_power_off(self.context, flavor_obj,
+                                              assert_compression=True)
 
     @mock.patch('nova.virt.libvirt.driver.LibvirtDriver._disconnect_volume')
     def test_migrate_disk_and_power_off_boot_from_volume(self,

--- a/nova/tests/unit/virt/libvirt/test_utils.py
+++ b/nova/tests/unit/virt/libvirt/test_utils.py
@@ -57,14 +57,14 @@ class LibvirtUtilsTestCase(test.NoDBTestCase):
         self.flags(remote_filesystem_transport='ssh', group='libvirt')
         libvirt_utils.copy_image('src', 'dest', host='host')
         mock_rem_fs_remove.assert_called_once_with('src', 'host:dest',
-            on_completion=None, on_execute=None, compression=True)
+            on_completion=None, on_execute=None, compression=False)
 
     @mock.patch('nova.virt.libvirt.volume.remotefs.RsyncDriver.copy_file')
     def test_copy_image_remote_rsync(self, mock_rem_fs_remove):
         self.flags(remote_filesystem_transport='rsync', group='libvirt')
         libvirt_utils.copy_image('src', 'dest', host='host')
         mock_rem_fs_remove.assert_called_once_with('src', 'host:dest',
-            on_completion=None, on_execute=None, compression=True)
+            on_completion=None, on_execute=None, compression=False)
 
     @mock.patch('os.path.exists', return_value=True)
     def test_disk_type_from_path(self, mock_exists):

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -226,11 +226,6 @@ MIN_LIBVIRT_AARCH64_CPU_COMPARE = (6, 9, 0)
 # Virtuozzo driver support
 MIN_VIRTUOZZO_VERSION = (7, 0, 0)
 
-
-# Names of the types that do not get compressed during migration
-NO_COMPRESSION_TYPES = ('qcow2',)
-
-
 # number of serial console limit
 QEMU_MAX_SERIAL_PORTS = 4
 # Qemu supports 4 serial consoles, we remove 1 because of the PTY one defined
@@ -11276,7 +11271,7 @@ class LibvirtDriver(driver.ComputeDriver):
                 if fname == 'disk.swap':
                     continue
 
-                compression = info['type'] not in NO_COMPRESSION_TYPES
+                compression = CONF.libvirt.remote_copy_compression
                 libvirt_utils.copy_image(from_path, img_path, host=dest,
                                          on_execute=on_execute,
                                          on_completion=on_completion,

--- a/nova/virt/libvirt/utils.py
+++ b/nova/virt/libvirt/utils.py
@@ -248,7 +248,7 @@ def copy_image(
     receive: bool = False,
     on_execute: ty.Callable = None,
     on_completion: ty.Callable = None,
-    compression: bool = True,
+    compression: bool = False,
 ) -> None:
     """Copy a disk image to an existing directory
 

--- a/nova/virt/libvirt/volume/remotefs.py
+++ b/nova/virt/libvirt/volume/remotefs.py
@@ -99,7 +99,7 @@ class RemoteFilesystem(object):
                                on_completion=on_completion)
 
     def copy_file(self, src, dst, on_execute=None,
-                    on_completion=None, compression=True):
+                    on_completion=None, compression=False):
         LOG.debug("Copying file %s to %s", src, dst)
         self.driver.copy_file(src, dst, on_execute=on_execute,
                               on_completion=on_completion,

--- a/releasenotes/notes/ssh-compression-config-4633a047e410983e.yaml
+++ b/releasenotes/notes/ssh-compression-config-4633a047e410983e.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    A new configuration option [libvirt]/remote_copy_compression has been
+    added. This option replaces the static list of disk formats which use
+    SSH compression for remote copy operations.
+
+    On fast local networks compression often reduces the copy bandwidth because
+    the CPU cannot compress fast enough.
+
+    By default compression is disabled. In previous releases compression was
+    for the raw, flat, lvm and ploop disks types.


### PR DESCRIPTION
Add a configuration option to enable SSH compression for copying ephemeral disks to remote hosts. This replaces the static list NO_COMPRESSION_TYPES.

On fast local networks compression actually reduces the copy bandwith because of the CPU overhead.

Implements: blueprint configurable-no-compression-image-types Change-Id: Ia935b45c56f81d5922608e37d5f263e5dd2e8a6f (cherry picked from commit 2a49c17dd526505f1b145d875542910778c88e02)