### PR TITLE
Resize ephemeral disk on instance resize

### DIFF
--- a/api-ref/source/servers-actions.inc
+++ b/api-ref/source/servers-actions.inc
@@ -828,7 +828,8 @@ automatically confirms the resize operation after the configured interval.
 .. _resize_confirm_window: https://docs.openstack.org/nova/latest/configuration/config.html#DEFAULT.resize_confirm_window
 
 .. note:: There is a `known limitation <https://bugs.launchpad.net/nova/+bug/1558880>`__
-          that ephemeral disks are not resized.
+          that ephemeral disks are not resized if they are smaller than the
+          flavors ephemeral size or if there are multiple ephemeral disks.
 
 Normal response codes: 202
 

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -4579,6 +4579,7 @@ class ComputeManager(manager.Manager):
         instance.old_flavor = None
         instance.new_flavor = None
         instance.system_metadata.pop('old_vm_state', None)
+        instance.system_metadata.pop('old_disk_sizes', None)
         instance.save()
 
     @wrap_exception()
@@ -5073,6 +5074,13 @@ class ComputeManager(manager.Manager):
             # compatibility if old_vm_state is not set
             old_vm_state = instance.system_metadata.get(
                 'old_vm_state', vm_states.ACTIVE)
+            old_sizes = instance.system_metadata.get('old_disk_sizes')
+            if old_sizes:
+                self._revert_resize_ephemeral_bdms(context, instance,
+                                                   jsonutils.loads(old_sizes))
+                # Refresh bdms
+                bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
+                    context, instance.uuid)
 
             # Revert the flavor and host/node fields to their previous values
             self._revert_instance_flavor_host_node(instance, migration)
@@ -5851,6 +5859,176 @@ class ComputeManager(manager.Manager):
                     self.volume_api.attachment_complete(
                         context, bdm.attachment_id)
 
+    def _update_ephemeral_bdms(self, context, instance, block_device_info,
+                               ephemeral_size, swap_size):
+        """Update ephemeral bdm objects in DB (for instance resizing).
+
+        Updates volume size of block device mapping object according to
+        specified new size. Works only for a single ephemeral and swap disks.
+        Stores the result into the DB.
+
+        Creates a new bdm if necessary.
+
+        :param context: Request context object.
+        :param instance: An instance which bdms are to be updated.
+        :param block_device_info: Instance block device mapping in driver
+                                  format.
+        :param ephemeral_size: New size in GB of the single ephemeral disk.
+                               Creates a new bdm if no bdm exists.
+                               If None - does nothing with ephemerals.
+                               If 0 - removes the ephemeral disk
+        :param swap_size: A size in MB of swap disk. Creates a new bdm if no
+                          swap bdm exists and non zero size is specified.
+                          Destroys swap bdm if zero size is specified.
+                          If None - does nothing with swap.
+        """
+        ephemerals = driver.block_device_info_get_ephemerals(block_device_info)
+        swap = driver.block_device_info_get_swap(block_device_info)
+        reassing_device_names = False
+
+        # Resize ephemeral disk
+        if ephemeral_size is not None:
+            if not ephemerals and ephemeral_size > 0:
+                LOG.debug(
+                    f'Creating ephemeral bdm: size={ephemeral_size}.',
+                    instance=instance
+                )
+                bdm = objects.BlockDeviceMapping(
+                    context=context, instance_uuid=instance.uuid,
+                    source_type='blank', destination_type='local',
+                    device_type='disk', delete_on_termination=True,
+                    boot_index=-1, volume_size=ephemeral_size)
+                bdm.create()
+                reassing_device_names = True
+            elif len(ephemerals) == 1 and ephemeral_size == 0:
+                LOG.debug('Deleting ephemeral bdm.', instance=instance)
+                ephemerals[0].destroy()
+                reassing_device_names = True
+            elif len(ephemerals) == 1:
+                LOG.debug(
+                    f'Resizing ephemeral bdm: new_size={ephemeral_size}, '
+                    f'old_size={ephemerals[0].volume_size}.',
+                    instance=instance,
+                )
+                ephemerals[0].volume_size = ephemeral_size
+                ephemerals[0].save()
+
+        # Resize swap
+        if swap_size is not None:
+            if swap['swap_size'] == 0 and swap_size > 0:
+                LOG.debug(
+                    f'Creating swap bdm: size={swap_size}.',
+                    instance=instance,
+                )
+                bdm = objects.BlockDeviceMapping(
+                    context=context, instance_uuid=instance.uuid,
+                    source_type='blank', destination_type='local',
+                    device_type='disk', guest_format='swap',
+                    boot_index=-1, volume_size=swap_size)
+                bdm.create()
+                reassing_device_names = True
+            elif swap['swap_size'] > 0 and swap_size == 0:
+                LOG.debug('Deleting swap bdm.', instance=instance)
+                swap.destroy()
+                reassing_device_names = True
+            elif swap['swap_size'] != swap_size:
+                LOG.debug(
+                    f'Resizing swap bdm: old_size={swap.volume_size} '
+                    f'new_size={swap_size}',
+                    instance=instance,
+                )
+                swap.volume_size = swap_size
+                swap.save()
+
+        if reassing_device_names:
+            bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
+                    context, instance.uuid)
+            self._default_block_device_names(instance, None, bdms)
+
+    def _resize_ephemeral_bdms(self, context, instance, bdms):
+        """Resize ephemeral bdm objects in DB (for instance resizing).
+
+        For an instance in resizing state (having actual old and new flavor
+        fields) this method resizes the instance's ephemeral and swap bdms
+        objects, persists them into DB, preparing them to be used by virt
+        driver to create/resize disks.
+
+        Supported features:
+        - add/remove/resize swap disk;
+        - add/increase single ephemeral disk;
+        - keep custom user specified ephemeral/swap size if it differs from
+            flavor specified size.
+
+        :param context: Request context object.
+        :param instance: An instance which bdms are to be resized.
+        :returns: A serializable object contains original bdm sizes.
+        """
+
+        block_device_info = self._get_instance_block_device_info(
+            context, instance, bdms=bdms)
+
+        # Handle ephemeral disk resizing
+        old_ephemeral_flavor = instance.old_flavor.ephemeral_gb
+        new_ephemeral_flavor = instance.new_flavor.ephemeral_gb
+        ephemerals = driver.block_device_info_get_ephemerals(block_device_info)
+        old_ephemeral_size = new_ephemeral_size = None
+
+        changed = old_ephemeral_flavor != new_ephemeral_flavor
+        single_ephemeral = len(ephemerals) == 1
+
+        # Current config uses the maximum ephemeral disk size of the old flavor
+        max_size = (
+            (len(ephemerals) == 0 and old_ephemeral_flavor == 0) or
+            (single_ephemeral and
+             old_ephemeral_flavor == ephemerals[0]['size'])
+        )
+
+        if changed and max_size:
+            old_ephemeral_size = (ephemerals[0]['size'] if len(ephemerals) > 0
+                                  else 0)
+            new_ephemeral_size = new_ephemeral_flavor
+
+        # Handle Swap resizing
+        swap = driver.block_device_info_get_swap(block_device_info)
+        old_swap_size = new_swap_size = None
+
+        if (instance.new_flavor.swap != instance.old_flavor.swap and
+            (swap['swap_size'] == instance.old_flavor.swap or
+             swap['swap_size'] > instance.new_flavor.swap)):
+            old_swap_size = swap['swap_size']
+            new_swap_size = instance.new_flavor.swap
+
+        if new_ephemeral_size is not None or new_swap_size is not None:
+            self._update_ephemeral_bdms(context, instance, block_device_info,
+                                        new_ephemeral_size, new_swap_size)
+
+        return old_ephemeral_size, old_swap_size
+
+    def _revert_resize_ephemeral_bdms(self, context, instance, old_disk_sizes):
+        """Revert resized ephemeral bdm objects in DB (for instance resizing).
+
+        Restore ephemeral and swap bdms previously resized with
+        _resize_ephemeral_bdms.
+
+        :param context: Request context object.
+        :param instance: An instance which bdms are to be reverted.
+        :param old_disk_sizes: An object created with _resize_ephemeral_bdms.
+        """
+        old_ephemeral_size, old_swap_size = old_disk_sizes
+        if old_ephemeral_size is None and old_swap_size is None:
+            return
+
+        LOG.debug(
+            f'Reverting ephemeral bdms: ephemeral_size={old_ephemeral_size}, '
+            f'swap_size={old_swap_size}.',
+            instance=instance,
+        )
+        bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
+                context, instance.uuid)
+        block_device_info = driver.get_block_device_info(instance, bdms)
+        self._update_ephemeral_bdms(context, instance, block_device_info,
+                                    old_ephemeral_size, old_swap_size)
+
     def _finish_resize(self, context, instance, migration, disk_info,
                        image_meta, bdms, request_spec):
         resize_instance = False  # indicates disks have been resized
@@ -5877,6 +6055,11 @@ class ComputeManager(manager.Manager):
                 if old_flavor[key] != new_flavor[key]:
                     resize_instance = True
                     break
+            if resize_instance:
+                old_sizes = self._resize_ephemeral_bdms(
+                    context, instance, bdms)
+                instance.system_metadata['old_disk_sizes'] = jsonutils.dumps(
+                    old_sizes)
         instance.apply_migration_context()
 
         # NOTE(tr3buchet): setup networks on destination host

--- a/nova/tests/unit/compute/test_compute.py
+++ b/nova/tests/unit/compute/test_compute.py
@@ -4737,10 +4737,16 @@ class ComputeTestCase(BaseTestCase,
         fake_bdms = objects.BlockDeviceMappingList(objects=[
             objects.BlockDeviceMapping(destination_type='volume',
                                        attachment_id=uuids.attachment_id,
-                                       device_name='/dev/vdb'),
+                                       device_name='/dev/vdb',
+                                       no_device=False,
+                                       source_type=None),
             objects.BlockDeviceMapping(destination_type='volume',
-                                       attachment_id=None),
-            objects.BlockDeviceMapping(destination_type='local')
+                                       attachment_id=None,
+                                       no_device=False,
+                                       source_type=None),
+            objects.BlockDeviceMapping(destination_type='local',
+                                       no_device=False,
+                                       source_type=None)
         ])
 
         with test.nested(
@@ -4759,11 +4765,13 @@ class ComputeTestCase(BaseTestCase,
             mock.patch.object(instance, 'save'),
             mock.patch.object(self.compute.driver, 'get_volume_connector'),
             mock.patch.object(self.compute.volume_api, 'attachment_update'),
-            mock.patch.object(self.compute.volume_api, 'attachment_complete')
+            mock.patch.object(self.compute.volume_api, 'attachment_complete'),
+            mock.patch('nova.virt.driver.block_device_info_get_ephemerals'),
+            mock.patch('nova.virt.driver.block_device_info_get_swap')
         ) as (mock_get_bdm, mock_setup, mock_net_mig, mock_get_nw, mock_notify,
               mock_notify_action, mock_virt_mig, mock_get_blk, mock_mig_save,
               mock_inst_save, mock_get_vol_connector, mock_attachment_update,
-              mock_attachment_complete):
+              mock_attachment_complete, mock_get_ephemerals, mock_get_swap):
             def _mig_save():
                 self.assertEqual(migration.status, 'finished')
                 self.assertEqual(vm_state, instance.vm_state)
@@ -4835,9 +4843,9 @@ class ComputeTestCase(BaseTestCase,
                 instance, disk_info, 'fake-nwinfo1',
                 test.MatchType(objects.ImageMeta), resize_instance, mock.ANY,
                 'fake-bdminfo', power_on)
-            mock_get_blk.assert_called_once_with(self.context, instance,
-                                                 refresh_conn_info=True,
-                                                 bdms=fake_bdms)
+            mock_get_blk.assert_called_with(self.context, instance,
+                                            refresh_conn_info=True,
+                                            bdms=fake_bdms)
             mock_inst_save.assert_has_calls(inst_call_list)
             mock_mig_save.assert_called_once_with()
 

--- a/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/tests/unit/compute/test_compute_mgr.py
@@ -12729,3 +12729,577 @@ class ComputeManagerSetHostEnabledTestCase(test.NoDBTestCase):
         self.assertIn('An error occurred while updating '
                       'COMPUTE_STATUS_DISABLED trait',
                       m_exc.call_args_list[0][0][0])
+
+
+@mock.patch('nova.objects.BlockDeviceMappingList.get_by_instance_uuid')
+@mock.patch.object(objects.BlockDeviceMapping, 'create', autospec=True)
+@mock.patch.object(objects.BlockDeviceMapping, 'destroy', autospec=True)
+@mock.patch.object(objects.BlockDeviceMapping, 'save', autospec=True)
+class ComputeManagerBDMResizeTestCase(test.NoDBTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.flags(compute_driver='fake.SameHostColdMigrateDriver')
+        self.compute = manager.ComputeManager()
+        self.context = context.RequestContext(
+            fakes.FAKE_USER_ID,
+            fakes.FAKE_PROJECT_ID,
+        )
+
+    def _create_migration_instance(
+            self,
+            old_flavor_ephemeral=0,
+            old_flavor_swap=0,
+            new_flavor_ephemeral=0,
+            new_flavor_swap=0,
+            instance_ephemerals=None,
+            instance_swap=None,
+    ):
+        old_flavor = fake_flavor.fake_flavor_obj(
+            self.context,
+            name='old-flavor',
+            id=1,
+            flavorid='1',
+            ephemeral_gb=old_flavor_ephemeral,
+            swap=old_flavor_swap,
+        )
+
+        new_flavor = fake_flavor.fake_flavor_obj(
+            self.context,
+            name='new-flavor',
+            id=2,
+            flavorid='2',
+            ephemeral_gb=new_flavor_ephemeral,
+            swap=new_flavor_swap,
+        )
+
+        instance = fake_instance.fake_instance_obj(
+            self.context,
+            flavor=old_flavor,
+            vm_state=vm_states.ACTIVE,
+            expected_attrs=['metadata', 'system_metadata', 'info_cache'],
+        )
+
+        # This would be set in _finish_resize
+        instance.old_flavor = instance.flavor
+        # This would be set in _prep_resize
+        instance.new_flavor = new_flavor
+
+        # Root disk
+        bdm_objects = [
+            fake_block_device.fake_bdm_object(
+                self.context,
+                dict(source_type='image',
+                     destination_type='local',
+                     boot_index=0,
+                     image_id=uuids.image_id,
+                     device_name='/dev/vda',
+                     volume_size=1))
+        ]
+
+        # Ephemeral disks
+        if instance_ephemerals:
+            for i, size in enumerate(instance_ephemerals):
+                bdm_objects.append(
+                    fake_block_device.fake_bdm_object(
+                        self.context,
+                        dict(source_type='blank',
+                             destination_type='local',
+                             device_type='disk',
+                             boot_index=-1,
+                             # Ephemeral disks start at /dev/vdb
+                             device_name=f'/dev/vd{chr(ord("b") + i)}',
+                             volume_size=size)
+                    )
+                )
+
+        # Swap disks
+        if instance_swap:
+            bdm_objects.append(
+                fake_block_device.fake_bdm_object(
+                    self.context,
+                    dict(source_type='blank',
+                         destination_type='local',
+                         device_type='disk',
+                         guest_format='swap',
+                         boot_index=-1,
+                         volume_size=instance_swap),
+                )
+            )
+
+        bdm_list = objects.BlockDeviceMappingList(objects=bdm_objects)
+
+        return instance, bdm_list
+
+    def _setup_mocks(self, mock_bdm_get, mock_create, mock_destroy, bdm_list):
+
+        def create(_self):
+
+            # Set UUID and ID
+            _self.uuid = uuids.bdm
+            _self.id = 1
+
+            # Fill in any unset fields with default values
+            for field in _self.fields:
+                if field not in _self._changed_fields:
+                    if _self.fields[field].nullable:
+                        value = None
+                    else:
+                        value = _self.fields[field].default
+
+                    setattr(_self, field, value)
+
+            bdm_list.objects.append(_self)
+
+        def destroy(_self):
+            bdm_list.objects.remove(_self)
+
+        mock_create.side_effect = create
+        mock_destroy.side_effect = destroy
+        mock_bdm_get.return_value = bdm_list
+
+    def test_resize_ephemeral_bdms_single_full(
+            self,
+            mock_save,
+            mock_destroy,
+            mock_create,
+            mock_bdm_get
+    ):
+        """Test resizing a single ephemeral disk using the full allocation of
+        the flavor. The disk should be resized to the ephemeral size of the
+        new flavor.
+        """
+
+        instance, bdms = self._create_migration_instance(
+            old_flavor_ephemeral=1,
+            new_flavor_ephemeral=2,
+            instance_ephemerals=[1],
+        )
+
+        self._setup_mocks(mock_bdm_get, mock_create, mock_destroy, bdms)
+
+        old_sizes = self.compute._resize_ephemeral_bdms(
+            self.context,
+            instance,
+            bdms,
+        )
+
+        self.assertEqual(bdms[1].volume_size, 2)
+        self.assertEqual(old_sizes, (1, None))
+        mock_save.assert_called_once()
+
+        # Test reverting
+        mock_save.reset_mock()
+        mock_create.reset_mock()
+        mock_destroy.reset_mock()
+
+        self.compute._revert_resize_ephemeral_bdms(
+            self.context,
+            instance,
+            old_sizes,
+        )
+
+        mock_save.assert_called_once()
+        mock_create.assert_not_called()
+        mock_destroy.assert_not_called()
+        self.assertEqual(bdms[1].volume_size, 1)
+
+    def test_resize_ephemeral_bdms_single_ephemeral_smaller(
+            self,
+            mock_save,
+            mock_destroy,
+            mock_create,
+            mock_bdm_get
+    ):
+        """Test resizing a single ephemeral disk not using the full allocation
+        of the flavor. The disk should not be resized.
+        """
+        instance, bdms = self._create_migration_instance(
+            old_flavor_ephemeral=2,
+            new_flavor_ephemeral=3,
+            instance_ephemerals=[1],
+        )
+
+        self._setup_mocks(mock_bdm_get, mock_create, mock_destroy, bdms)
+
+        old_sizes = self.compute._resize_ephemeral_bdms(
+            self.context,
+            instance,
+            bdms,
+        )
+
+        self.assertEqual(bdms[1].volume_size, 1)
+        self.assertEqual(old_sizes, (None, None))
+        mock_save.assert_not_called()
+
+        # Test reverting
+        mock_save.reset_mock()
+        mock_create.reset_mock()
+        mock_destroy.reset_mock()
+
+        self.compute._revert_resize_ephemeral_bdms(
+            self.context,
+            instance,
+            old_sizes,
+        )
+
+        mock_save.assert_not_called()
+        mock_create.assert_not_called()
+        mock_destroy.assert_not_called()
+        self.assertEqual(bdms[1].volume_size, 1)
+
+    def test_resize_ephemeral_bdms_multiple_ephemerals(
+            self,
+            mock_save,
+            mock_destroy,
+            mock_create,
+            mock_bdm_get
+    ):
+        """Test resizing with multiple ephemeral disks. This should not change
+        the ephemeral disk sizes.
+        """
+        instance, bdms = self._create_migration_instance(
+            old_flavor_ephemeral=3,
+            new_flavor_ephemeral=4,
+            instance_ephemerals=[2, 1],
+        )
+
+        self._setup_mocks(mock_bdm_get, mock_create, mock_destroy, bdms)
+
+        old_sizes = self.compute._resize_ephemeral_bdms(
+            self.context,
+            instance,
+            bdms,
+        )
+
+        self.assertEqual(bdms[1].volume_size, 2)
+        self.assertEqual(bdms[2].volume_size, 1)
+        self.assertEqual(old_sizes, (None, None))
+        mock_save.assert_not_called()
+
+        # Test reverting
+        mock_save.reset_mock()
+        mock_create.reset_mock()
+        mock_destroy.reset_mock()
+
+        self.compute._revert_resize_ephemeral_bdms(
+            self.context,
+            instance,
+            old_sizes,
+        )
+
+        mock_save.assert_not_called()
+        mock_create.assert_not_called()
+        mock_destroy.assert_not_called()
+        self.assertEqual(bdms[1].volume_size, 2)
+        self.assertEqual(bdms[2].volume_size, 1)
+
+    def test_resize_ephemeral_bdms_to_single_ephemeral(
+            self,
+            mock_save,
+            mock_destroy,
+            mock_create,
+            mock_bdm_get
+    ):
+        """Test resizing an instance without an ephemeral disk to a flavor
+        with ephemeral storage. This should add an ephemeral disk.
+        """
+        instance, bdms = self._create_migration_instance(
+            old_flavor_ephemeral=0,
+            new_flavor_ephemeral=1,
+            instance_ephemerals=[],
+        )
+
+        self._setup_mocks(mock_bdm_get, mock_create, mock_destroy, bdms)
+
+        old_sizes = self.compute._resize_ephemeral_bdms(
+            self.context,
+            instance,
+            bdms,
+        )
+
+        mock_create.assert_called_once()
+        mock_save.assert_called_once()  # after assigning device name
+        mock_destroy.assert_not_called()
+        self.assertEqual(old_sizes, (0, None))
+        self.assertEqual(len(bdms), 2)
+        self.assertEqual(bdms[1].volume_size, 1)
+
+        # Test reverting
+        mock_save.reset_mock()
+        mock_create.reset_mock()
+        mock_destroy.reset_mock()
+
+        self.compute._revert_resize_ephemeral_bdms(
+            self.context,
+            instance,
+            old_sizes,
+        )
+
+        mock_save.assert_not_called()
+        mock_create.assert_not_called()
+        mock_destroy.assert_called_once()
+        self.assertEqual(len(bdms), 1)
+
+    def test_resize_ephemeral_bdms_swap_full_larger(
+            self,
+            mock_save,
+            mock_destroy,
+            mock_create,
+            mock_bdm_get
+    ):
+        """Test resizing to a flavor with more swap space if all swap space
+        allowed by the current flavor is used. Swap will be resized.
+        """
+        instance, bdms = self._create_migration_instance(
+            old_flavor_swap=1,
+            new_flavor_swap=2,
+            instance_swap=1,
+        )
+
+        self._setup_mocks(mock_bdm_get, mock_create, mock_destroy, bdms)
+
+        old_sizes = self.compute._resize_ephemeral_bdms(
+            self.context,
+            instance,
+            bdms,
+        )
+
+        self.assertEqual(bdms[1].volume_size, 2)
+        self.assertEqual(old_sizes, (None, 1))
+        mock_save.assert_called_once()
+
+        # Test reverting
+        mock_save.reset_mock()
+        mock_create.reset_mock()
+        mock_destroy.reset_mock()
+
+        self.compute._revert_resize_ephemeral_bdms(
+            self.context,
+            instance,
+            old_sizes,
+        )
+
+        mock_save.assert_called_once()
+        mock_create.assert_not_called()
+        mock_destroy.assert_not_called()
+        self.assertEqual(bdms[1].volume_size, 1)
+
+    def test_resize_ephemeral_bdms_swap_full_smaller(
+            self,
+            mock_save,
+            mock_destroy,
+            mock_create,
+            mock_bdm_get
+    ):
+        """Test resizing to a flavor with less swap space if all swap space
+        allowed by the current flavor is used. Swap will always be resized.
+        """
+        instance, bdms = self._create_migration_instance(
+            old_flavor_swap=2,
+            new_flavor_swap=1,
+            instance_swap=2,
+        )
+
+        self._setup_mocks(mock_bdm_get, mock_create, mock_destroy, bdms)
+
+        old_sizes = self.compute._resize_ephemeral_bdms(
+            self.context,
+            instance,
+            bdms,
+        )
+
+        self.assertEqual(bdms[1].volume_size, 1)
+        self.assertEqual(old_sizes, (None, 2))
+        mock_save.assert_called_once()
+
+        # Test reverting
+        mock_save.reset_mock()
+        mock_create.reset_mock()
+        mock_destroy.reset_mock()
+
+        self.compute._revert_resize_ephemeral_bdms(
+            self.context,
+            instance,
+            old_sizes,
+        )
+
+        mock_save.assert_called_once()
+        mock_create.assert_not_called()
+        mock_destroy.assert_not_called()
+        self.assertEqual(bdms[1].volume_size, 2)
+
+    def test_resize_ephemeral_bdms_swap_unused(
+            self,
+            mock_save,
+            mock_destroy,
+            mock_create,
+            mock_bdm_get
+    ):
+        """Test resizing to a flavor with more swap space if not all swap
+        space allowed by the old flavor is used. Swap will not be resized.
+        """
+        instance, bdms = self._create_migration_instance(
+            old_flavor_swap=2,
+            new_flavor_swap=3,
+            instance_swap=1,
+        )
+
+        self._setup_mocks(mock_bdm_get, mock_create, mock_destroy, bdms)
+
+        old_sizes = self.compute._resize_ephemeral_bdms(
+            self.context,
+            instance,
+            bdms,
+        )
+
+        self.assertEqual(bdms[1].volume_size, 1)
+        self.assertEqual(old_sizes, (None, None))
+        mock_save.assert_not_called()
+
+        # Test reverting
+        mock_save.reset_mock()
+        mock_create.reset_mock()
+        mock_destroy.reset_mock()
+
+        self.compute._revert_resize_ephemeral_bdms(
+            self.context,
+            instance,
+            old_sizes,
+        )
+
+        mock_save.assert_not_called()
+        mock_create.assert_not_called()
+        mock_destroy.assert_not_called()
+        self.assertEqual(bdms[1].volume_size, 1)
+
+    def test_resize_ephemeral_bdms_swap_too_large(
+            self,
+            mock_save,
+            mock_destroy,
+            mock_create,
+            mock_bdm_get
+    ):
+        """Test resizing to a flavor with less swap space than allowed by the
+        new flavor for an instance that does not use all swap space allowed
+        by the old flavor. Swap will be sized down to the new flavor.
+        """
+        instance, bdms = self._create_migration_instance(
+            old_flavor_swap=3,
+            new_flavor_swap=1,
+            instance_swap=2,
+        )
+
+        self._setup_mocks(mock_bdm_get, mock_create, mock_destroy, bdms)
+
+        old_sizes = self.compute._resize_ephemeral_bdms(
+            self.context,
+            instance,
+            bdms,
+        )
+
+        self.assertEqual(bdms[1].volume_size, 1)
+        self.assertEqual(old_sizes, (None, 2))
+        mock_save.assert_called_once()
+
+        # Test reverting
+        mock_save.reset_mock()
+        mock_create.reset_mock()
+        mock_destroy.reset_mock()
+
+        self.compute._revert_resize_ephemeral_bdms(
+            self.context,
+            instance,
+            old_sizes,
+        )
+
+        mock_save.assert_called_once()
+        mock_create.assert_not_called()
+        mock_destroy.assert_not_called()
+        self.assertEqual(bdms[1].volume_size, 2)
+
+    def test_resize_ephemeral_bdms_to_noswap(
+            self,
+            mock_save,
+            mock_destroy,
+            mock_create,
+            mock_bdm_get
+    ):
+        """Test resizing from a flavor with swap space to one without swap."""
+        instance, bdms = self._create_migration_instance(
+            old_flavor_swap=1,
+            new_flavor_swap=0,
+            instance_swap=1,
+        )
+
+        self._setup_mocks(mock_bdm_get, mock_create, mock_destroy, bdms)
+
+        old_sizes = self.compute._resize_ephemeral_bdms(
+            self.context,
+            instance,
+            bdms,
+        )
+
+        mock_destroy.assert_called_once()
+        mock_save.assert_not_called()
+        self.assertEqual(old_sizes, (None, 1))
+        self.assertEqual(len(bdms), 1)
+
+        # Test reverting
+        mock_save.reset_mock()
+        mock_create.reset_mock()
+        mock_destroy.reset_mock()
+
+        self.compute._revert_resize_ephemeral_bdms(
+            self.context,
+            instance,
+            old_sizes,
+        )
+
+        mock_save.assert_called_once()  # after assigning device name
+        mock_create.assert_called_once()
+        mock_destroy.assert_not_called()
+        self.assertEqual(bdms[1].volume_size, 1)
+
+    def test_resize_ephemeral_bdms_to_swap(
+            self,
+            mock_save,
+            mock_destroy,
+            mock_create,
+            mock_bdm_get
+    ):
+        """Test resizing from a flavor without swap space to one with swap."""
+        instance, bdms = self._create_migration_instance(
+            old_flavor_swap=0,
+            new_flavor_swap=1
+        )
+
+        self._setup_mocks(mock_bdm_get, mock_create, mock_destroy, bdms)
+
+        old_sizes = self.compute._resize_ephemeral_bdms(
+            self.context,
+            instance,
+            bdms,
+        )
+
+        mock_create.assert_called_once()
+        mock_save.assert_called_once()  # after assigning device name
+        self.assertEqual(old_sizes, (None, 0))
+        self.assertEqual(len(bdms), 2)
+        self.assertEqual(bdms[1].volume_size, 1)
+
+        # Test reverting
+        mock_save.reset_mock()
+        mock_create.reset_mock()
+        mock_destroy.reset_mock()
+
+        self.compute._revert_resize_ephemeral_bdms(
+            self.context,
+            instance,
+            old_sizes,
+        )
+
+        mock_save.assert_not_called()
+        mock_create.assert_not_called()
+        mock_destroy.assert_called_once()
+        self.assertEqual(len(bdms), 1)

--- a/nova/tests/unit/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/unit/virt/libvirt/test_imagebackend.py
@@ -196,13 +196,12 @@ class _ImageTestCase(object):
         self.assertEqual(30 * units.Mi, disk.disk_total_bytes_sec)
         self.assertEqual(3 * units.Ki, disk.disk_total_iops_sec)
 
-    @mock.patch('nova.virt.disk.api.get_disk_size')
-    def test_get_disk_size(self, get_disk_size):
+    def _test_get_disk_size(self, get_disk_size, size_call_attr='path'):
         get_disk_size.return_value = 2361393152
 
         image = self.image_class(self.INSTANCE, self.NAME)
         self.assertEqual(2361393152, image.get_disk_size(image.path))
-        get_disk_size.assert_called_once_with(image.path)
+        get_disk_size.assert_called_once_with(getattr(image, size_call_attr))
 
     def _test_libvirt_info_scsi_with_unit(self, disk_unit):
         # The address should be set if bus is scsi and unit is set.
@@ -841,9 +840,11 @@ class LvmTestCase(_ImageTestCase, test.NoDBTestCase):
 
         mock_exists.side_effect = fake_exists
 
-        # Fake create_volume causes exists to return true for the volume
+        # Fake create_volume causes exists to return true and set the size for
+        # the volume
         def fake_create_volume(vg, lv, size, sparse=False):
             exists.add(os.path.join('/dev', vg, lv))
+            mock_lvm.get_volume_size.return_value = size
 
         mock_lvm.create_volume.side_effect = fake_create_volume
 
@@ -917,6 +918,10 @@ class LvmTestCase(_ImageTestCase, test.NoDBTestCase):
                                             sparse=False)
         fn.assert_called_once_with(target=self.PATH, ephemeral_size=None)
         mock_remove.assert_called_once_with([self.PATH])
+
+    @mock.patch('nova.virt.libvirt.storage.lvm.get_volume_size')
+    def test_get_disk_size(self, get_disk_size):
+        self._test_get_disk_size(get_disk_size)
 
     def test_prealloc_image(self):
         CONF.set_override('preallocate_images', 'space')
@@ -1264,6 +1269,10 @@ class EncryptedLvmTestCase(_ImageTestCase, test.NoDBTestCase):
                 self.PATH.rpartition('/')[2])
             self.lvm.remove_volumes.assert_called_with([self.LV_PATH])
 
+    @mock.patch('nova.virt.libvirt.storage.lvm.get_volume_size')
+    def test_get_disk_size(self, get_disk_size):
+        self._test_get_disk_size(get_disk_size)
+
     def test_prealloc_image(self):
         self.flags(preallocate_images='space')
         fake_processutils.fake_execute_clear_log()
@@ -1525,13 +1534,9 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
         self.assertEqual(image.path, rbd_path)
 
-    def test_get_disk_size(self):
-        image = self.image_class(self.INSTANCE, self.NAME)
-        with mock.patch.object(image.driver, 'size') as size_mock:
-            size_mock.return_value = 2361393152
-
-            self.assertEqual(2361393152, image.get_disk_size(image.path))
-            size_mock.assert_called_once_with(image.rbd_name)
+    @mock.patch('nova.storage.rbd_utils.RBDDriver.size')
+    def test_get_disk_size(self, get_disk_size):
+        self._test_get_disk_size(get_disk_size, 'rbd_name')
 
     @mock.patch.object(images, 'qemu_img_info',
                        return_value=imageutils.QemuImgInfo())

--- a/nova/virt/block_device.py
+++ b/nova/virt/block_device.py
@@ -210,9 +210,13 @@ class DriverBlockDevice(dict):
                 setattr(self._bdm_obj, attr_name, self[lookup_name])
         self._bdm_obj.save()
 
+    def destroy(self):
+        self._bdm_obj.destroy()
+
 
 class DriverSwapBlockDevice(DriverBlockDevice):
     _fields = set(['device_name', 'swap_size', 'disk_bus'])
+    _proxy_as_attr_inherited = set(['volume_size'])
 
     _update_on_save = {'disk_bus': None,
                        'device_name': None}
@@ -230,6 +234,7 @@ class DriverSwapBlockDevice(DriverBlockDevice):
 class DriverEphemeralBlockDevice(DriverBlockDevice):
     _new_only_fields = set(['disk_bus', 'device_type', 'guest_format'])
     _fields = set(['device_name', 'size']) | _new_only_fields
+    _proxy_as_attr_inherited = set(['volume_size'])
 
     def _transform(self):
         if not block_device.new_format_is_ephemeral(self._bdm_obj):

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -278,7 +278,7 @@ class Image(metaclass=abc.ABCMeta):
         if size:
             # create_image() only creates the base image if needed, so
             # we cannot rely on it to exist here
-            if os.path.exists(base) and size > self.get_disk_size(base):
+            if os.path.exists(base) and size > self.get_disk_size(self.path):
                 self.resize_image(size)
 
             if (self.preallocate and self._can_fallocate() and
@@ -822,6 +822,9 @@ class Lvm(Image):
     # and migrate/resize is not supported with LVM yet, so this is a no-op
     def resize_image(self, size):
         pass
+
+    def get_disk_size(self, path):
+        return lvm.get_volume_size(path)
 
     @contextlib.contextmanager
     def remove_volume_on_error(self, path):


### PR DESCRIPTION
Block device mappings for ephemeral and swap disks are not resized during instance resize operations. This causes virt drivers to not resize them.

This patch resizes bdms for ephemeral and swap disks during finish_resize if:
- All space allowed by the old flavor is used.
- There is a single ephemeral disk or no ephemeral disk.
- Swap is reduced in all cases if the new flavor allows less swap than currently allocated. For all other cases, the disk configuration is not touched as it's unclear how to resize.

Note: Resizing to a flavor with less ephemeral disk space is not allowed and already prohibited in the API layer.

TODO from old change:
Virt driver related changes:
- libvirt: a new imagebackend method _get_original_template_name is added, which aim is to get template name of an existing disk, which differs from specified one from driver's _create_image method in the case of resizing. Really, if we resize an ephemeral disk from 10 GB to 20 GB, the bdm object is already has 20 GB size, and _create_image specifies template name for 20 GB disk, but existing disk is created from 10 GB template and must continue to work with it. There is no reason to charge driver with such details, so that the new virtual method of imagebackend is the best choice.

Resize ephemerals down details by drivers:
- hyperv prevents resizing down in finish_migration method (except resizing to zero, in which case it removes ephemeral disk). This method raises an exception, and the instance is goes to error state. Unfortunately the same occures with revert of resize up operation when ephemeral bdm size is decreasing. I.e. it looks like this patch brings a problem there;
- vmwareapi does not honor ephemeral bdms at all, but works with flavor ephemeral size directly. Moreover it recreates ephemeral disks on any resize operation. So that it probably does need to do something additionally with this patch;
- ironic does not seem to has resizing supported at all. Conclusions: if vmwareapi behavior (recreating of ephemerals) is legal, fix hyperv only; if not - an early performed common check preventing resizing down whould be suitable.

TODOes:
- fix handling of resized bdms in hyperv;
- check against lvm and ploop image backends;
- fix a bug with disk.info inconsistency for flat backend after resizing (disks becomes qcow2 while disk.info still has 'raw' for them);

Change-Id: Ie42a0b2f0019202c6cb1a1533a838a8549c000c8
Related-Bug: 1558880
Related-Bug: 1605720